### PR TITLE
Fix: Make search case-insensitive

### DIFF
--- a/script.js
+++ b/script.js
@@ -88,7 +88,7 @@ let inp = document.querySelector(".inp");
 
 inp.addEventListener("input", function () {
   let newUsers = users.filter((user) => {
-    return user.name.startsWith(inp.value);
+    return user.name.toLowerCase().startsWith(inp.value.toLowerCase());
   });
   if (newUsers.length === 0) {
     document.querySelector(".cards").innerHTML =


### PR DESCRIPTION
The search functionality was previously case-sensitive, which resulted in a poor user experience. This change modifies the search to be case-insensitive by converting both the user's name and the search input to lowercase before comparison.